### PR TITLE
Replace markdown-it-katexx with @traptitech/markdown-it-katex

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "dependencies": {
     "markdown-it": "^12.3.2",
-    "markdown-it-katexx": "^3.2.0"
+    "@traptitech/markdown-it-katex": "^3.6.0"
   },
   "devDependencies": {},
   "scripts": {

--- a/scripts/format-blogpost.js
+++ b/scripts/format-blogpost.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const fs = require('fs');
-const mk = require('markdown-it-katexx');
+const mk = require('@traptitech/markdown-it-katex');
 const markdown = require('markdown-it')(
 	{
 		html: true,


### PR DESCRIPTION
The page
```markdown
# Intro

Something $x = 2$ and 
$$
\begin{align}
a &= 2 \\
c &= 3
\end{align}
$$
```
doesn't render with `markdown-it-katexx` - but renders with `@traptitech/markdown-it-katex`. I think it's because `markdown-it-katexx` package is no longer maintained, and it seems that the support for `align` environment was added after it was abandoned.